### PR TITLE
Posts and Deletes for projects and completed climbs

### DIFF
--- a/app/src/main/java/com/rage/clamber/Activities/HomePage.java
+++ b/app/src/main/java/com/rage/clamber/Activities/HomePage.java
@@ -21,7 +21,7 @@ import butterknife.OnClick;
  */
 public class HomePage extends AppCompatActivity {
 
-    public static final String CONNECTION_WEB_ADDRESS = "http://149.175.37.161:8080/";
+    public static final String CONNECTION_WEB_ADDRESS = "http://192.168.0.105:8080/";
     public static final String ARG_USER = "main user";
     public User user;
 

--- a/app/src/main/java/com/rage/clamber/Adapters/ClimbsRecyclerViewAdapter.java
+++ b/app/src/main/java/com/rage/clamber/Adapters/ClimbsRecyclerViewAdapter.java
@@ -1,6 +1,7 @@
 package com.rage.clamber.Adapters;
 
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,6 +11,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.rage.clamber.Data.Climb;
+import com.rage.clamber.Fragments.ProjectsFragment;
 import com.rage.clamber.R;
 
 import java.util.List;
@@ -25,8 +27,21 @@ public class ClimbsRecyclerViewAdapter extends RecyclerView.Adapter<ClimbsRecycl
 
     protected List<Climb> climbs;
 
-    public ClimbsRecyclerViewAdapter(List<Climb> climbArrayList) {
+    public ClimbsRecyclerViewAdapter(List<Climb> climbArrayList, onProjectCheckBoxClickedListener ProjectcheckBoxlistener, onCompletedCheckBoxClickedListener CompletedCheckBoxListener) {
         climbs = climbArrayList;
+        projectlistener = ProjectcheckBoxlistener;
+        completedListener = CompletedCheckBoxListener;
+    }
+
+    private final onProjectCheckBoxClickedListener projectlistener;
+    private final onCompletedCheckBoxClickedListener completedListener;
+
+    public interface onProjectCheckBoxClickedListener {
+        public void onProjectCheckBoxClicked(int climbId,  boolean isChecked);
+    }
+
+    public interface onCompletedCheckBoxClickedListener{
+        public void onCompletedCheckBoxClicked(int climbId, boolean isChecked);
     }
 
     @Override
@@ -37,14 +52,36 @@ public class ClimbsRecyclerViewAdapter extends RecyclerView.Adapter<ClimbsRecycl
     }
 
     @Override
-    public void onBindViewHolder(ClimbsViewHolder holder, int position) {
+    public void onBindViewHolder(final ClimbsViewHolder holder, int position) {
         Climb climb = climbs.get(position);
+        Log.d(ProjectsFragment.TAG, "Climb id: " + climb.getClimbId());
         holder.gradeDataTextView.setText(Integer.toString(climb.getGymRating()));
         holder.projectCheckBox.setChecked(climb.isProject());
         holder.completedCheckBox.setChecked(climb.isCompleted());
         holder.styleDataTextView.setText(climb.getType());
         holder.routeColorTextView.setText(climb.getTape_color());
 
+        holder.projectCheckBox.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (projectlistener != null){
+                    Climb oneClimb = climbs.get(holder.getAdapterPosition());
+                    projectlistener.onProjectCheckBoxClicked(oneClimb.getClimbId(), oneClimb.isProject());
+                    oneClimb.setProject(!oneClimb.isProject());
+                }
+            }
+        });
+
+        holder.completedCheckBox.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (completedListener != null){
+                    Climb oneClimb = climbs.get(holder.getAdapterPosition());
+                    completedListener.onCompletedCheckBoxClicked(oneClimb.getClimbId(), oneClimb.isCompleted());
+                    oneClimb.setCompleted(!oneClimb.isCompleted());
+                }
+            }
+        });
     }
 
     @Override
@@ -82,10 +119,16 @@ public class ClimbsRecyclerViewAdapter extends RecyclerView.Adapter<ClimbsRecycl
         @Bind(R.id.climb_row_style_text)
         TextView styleTextView;
 
+        View fullView;
+
         public ClimbsViewHolder(View itemView) {
             super(itemView);
+            fullView = itemView;
+
             ButterKnife.bind(this, itemView);
 
         }
     }
+
+
 }

--- a/app/src/main/java/com/rage/clamber/Adapters/WallsPageRecyclerViewAdapter.java
+++ b/app/src/main/java/com/rage/clamber/Adapters/WallsPageRecyclerViewAdapter.java
@@ -9,7 +9,6 @@ import android.widget.TextView;
 import com.rage.clamber.Data.WallSection;
 import com.rage.clamber.R;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import butterknife.Bind;
@@ -23,7 +22,7 @@ public class WallsPageRecyclerViewAdapter extends RecyclerView.Adapter<WallsPage
     protected List<WallSection> wallSections;
 
 
-    public WallsPageRecyclerViewAdapter(ArrayList<WallSection> wallSectionArrayList, OnWallSelectedListener wallSelectedListener) {
+    public WallsPageRecyclerViewAdapter(List<WallSection> wallSectionArrayList, OnWallSelectedListener wallSelectedListener) {
         wallSections = wallSectionArrayList;
         listener = wallSelectedListener;
     }

--- a/app/src/main/java/com/rage/clamber/AsyncTasks/ClamberService.java
+++ b/app/src/main/java/com/rage/clamber/AsyncTasks/ClamberService.java
@@ -1,13 +1,18 @@
 package com.rage.clamber.AsyncTasks;
 
+import com.rage.clamber.AsyncTasks.Requests.UserClimbDataRequest;
 import com.rage.clamber.Data.Climb;
+import com.rage.clamber.Data.Project;
 import com.rage.clamber.Data.User;
 import com.rage.clamber.Data.WallSection;
 
 import java.util.List;
 
 import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
 import retrofit2.http.GET;
+import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 /**
@@ -26,4 +31,21 @@ public interface ClamberService {
 
     @GET("user/{username}/walls/{wall_id}/wall_sections/{wall_section_id}/climbs")
     public Call<List<Climb>> getClimbsByWallSection(@Path("username") String username, @Path("wall_id") int wallId, @Path("wall_section_id") int wallSectionId);
+
+    @POST("projects")
+    Call<Project> createProject(@Body UserClimbDataRequest request);
+
+    @DELETE("projects/{username}/climbs/{climb_id}")
+    Call<Boolean> removeProject(@Path("username") String username, @Path("climb_id") int climb_id);
+
+    @POST("completed")
+    Call<Boolean> createCompleted(@Body UserClimbDataRequest request);
+
+    @DELETE("completed/{username}/climbs/{climb_id}")
+    Call<Boolean> removeCompleted(@Path("username") String username, @Path("climb_id") int climb_id);
+
+
+
+
+
 }

--- a/app/src/main/java/com/rage/clamber/AsyncTasks/Requests/UserClimbDataRequest.java
+++ b/app/src/main/java/com/rage/clamber/AsyncTasks/Requests/UserClimbDataRequest.java
@@ -1,0 +1,27 @@
+package com.rage.clamber.AsyncTasks.Requests;
+
+/**
+ * Class to hold the user name and climb id for project and completed climb server requests.
+ */
+public class UserClimbDataRequest {
+
+    protected String username;
+    protected int climbId;
+
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public int getClimbId() {
+        return climbId;
+    }
+
+    public void setClimbId(int climbId) {
+        this.climbId = climbId;
+    }
+}

--- a/app/src/main/java/com/rage/clamber/Fragments/ClimbsFragment.java
+++ b/app/src/main/java/com/rage/clamber/Fragments/ClimbsFragment.java
@@ -125,7 +125,7 @@ public class ClimbsFragment extends Fragment implements ClimbsRecyclerViewAdapte
 
                 @Override
                 public void onFailure(Call<List<Climb>> call, Throwable t) {
-                    Log.d(TAG, "Failure while attempting to return climbs by wall section");
+                    Log.d(TAG, "Failure while attempting to return climbs by wall section", t);
 
                 }
             });
@@ -162,7 +162,7 @@ public class ClimbsFragment extends Fragment implements ClimbsRecyclerViewAdapte
 
                 @Override
                 public void onFailure(Call<Project> call, Throwable t) {
-                    Log.d(TAG, "Failed to set up project for user:" + mainUser.getUserName());
+                    Log.d(TAG, "Failed to set up project for user:" + mainUser.getUserName(), t);
                 }
             });
         } else {
@@ -180,7 +180,7 @@ public class ClimbsFragment extends Fragment implements ClimbsRecyclerViewAdapte
 
                 @Override
                 public void onFailure(Call<Boolean> call, Throwable t) {
-                    Log.d(TAG, "Failed to delete project for user: " + mainUser.getUserName());
+                    Log.d(TAG, "Failed to delete project for user: " + mainUser.getUserName(), t);
                 }
             });
         }
@@ -215,7 +215,7 @@ public class ClimbsFragment extends Fragment implements ClimbsRecyclerViewAdapte
 
                 @Override
                 public void onFailure(Call<Boolean> call, Throwable t) {
-                    Log.d(TAG, "Failed to set up completed climb for user:" + mainUser.getUserName());
+                    Log.d(TAG, "Failed to set up completed climb for user:" + mainUser.getUserName(), t);
 
                 }
 
@@ -235,7 +235,7 @@ public class ClimbsFragment extends Fragment implements ClimbsRecyclerViewAdapte
 
                 @Override
                 public void onFailure(Call<Boolean> call, Throwable t) {
-                    Log.d(TAG, "Failed to delete completed climb for user: " + mainUser.getUserName());
+                    Log.d(TAG, "Failed to delete completed climb for user: " + mainUser.getUserName(), t);
 
                 }
             });

--- a/app/src/main/java/com/rage/clamber/Fragments/ClimbsFragment.java
+++ b/app/src/main/java/com/rage/clamber/Fragments/ClimbsFragment.java
@@ -17,7 +17,9 @@ import android.view.ViewGroup;
 import com.rage.clamber.Activities.HomePage;
 import com.rage.clamber.Adapters.ClimbsRecyclerViewAdapter;
 import com.rage.clamber.AsyncTasks.ClamberService;
+import com.rage.clamber.AsyncTasks.Requests.UserClimbDataRequest;
 import com.rage.clamber.Data.Climb;
+import com.rage.clamber.Data.Project;
 import com.rage.clamber.Data.User;
 import com.rage.clamber.R;
 
@@ -35,7 +37,7 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 /**
  * Fragment to display climbs by WallSection
  */
-public class ClimbsFragment extends Fragment {
+public class ClimbsFragment extends Fragment implements ClimbsRecyclerViewAdapter.onProjectCheckBoxClickedListener, ClimbsRecyclerViewAdapter.onCompletedCheckBoxClickedListener {
 
     public static final String TAG = ClimbsFragment.class.getSimpleName();
     protected User mainUser;
@@ -53,8 +55,9 @@ public class ClimbsFragment extends Fragment {
 
     /**
      * Creates a ClimbsFragment. Launched from the WallSectionFragment.
-     * @param user - the logged in user.
-     * @param wallId - the main wall that is currently selected
+     *
+     * @param user          - the logged in user.
+     * @param wallId        - the main wall that is currently selected
      * @param wallSectionId - the specific wallSection that the climbs are on
      * @return - new climb fragment
      */
@@ -87,13 +90,14 @@ public class ClimbsFragment extends Fragment {
     /**
      * Method to make a network call to the Clamber Server to get all Climbs for the specified wall
      * section. It also updates the adapter to pass through the returned list of climbs.
-     * @param userName - userName is used in the database query to return project and completed statuses
+     *
+     * @param userName      - userName is used in the database query to return project and completed statuses
      * @param wallSectionId - wallSectionId tells the query what climbs to return.
      */
-    public void getClimbsByWallSection(String userName, int wallSectionId){
+    public void getClimbsByWallSection(String userName, int wallSectionId) {
         ConnectivityManager connectivityManager = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
-        if(networkInfo != null && networkInfo.isConnected()) {
+        if (networkInfo != null && networkInfo.isConnected()) {
             Retrofit retrofit = new Retrofit.Builder()
                     .baseUrl(HomePage.CONNECTION_WEB_ADDRESS)
                     .addConverterFactory(JacksonConverterFactory.create())
@@ -103,17 +107,16 @@ public class ClimbsFragment extends Fragment {
             climbsCall.enqueue(new Callback<List<Climb>>() {
                 @Override
                 public void onResponse(Call<List<Climb>> call, Response<List<Climb>> response) {
-                    if (response.code() == 200){
+                    if (response.code() == 200) {
                         List<Climb> climbs = response.body();
-                        for (int i = 0; i < climbs.size(); i++){
+                        for (int i = 0; i < climbs.size(); i++) {
                             climbArrayList.add(climbs.get(i));
                         }
 
-                        ClimbsRecyclerViewAdapter adapter = new ClimbsRecyclerViewAdapter(climbArrayList);
+                        ClimbsRecyclerViewAdapter adapter = new ClimbsRecyclerViewAdapter(climbArrayList, ClimbsFragment.this, ClimbsFragment.this);
                         recyclerView.setAdapter(adapter);
                         recyclerView.setItemAnimator(new DefaultItemAnimator());
-                    }
-                    else {
+                    } else {
                         Log.d(TAG, "Non 200 response code returned - check server");
                     }
 
@@ -130,4 +133,112 @@ public class ClimbsFragment extends Fragment {
         }
     }
 
+    /**
+     * Method called from the ClimbRecyclerViewAdapter when the Project Checkbox is clicked. It returns the
+     * climb Id and boolean value for whether or not the box is checked. With that information, a network
+     * call is made to either POST a new project to the database or DELETE an existing project for the user.
+     * @param climbId - the id of the climb where the project checkbox was selected
+     * @param isChecked - the boolean value of the project checkbox.
+     */
+    @Override
+    public void onProjectCheckBoxClicked(int climbId, boolean isChecked) {
+        UserClimbDataRequest request = new UserClimbDataRequest();
+        request.setClimbId(climbId);
+        request.setUsername(mainUser.getUserName());
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(HomePage.CONNECTION_WEB_ADDRESS)
+                .addConverterFactory(JacksonConverterFactory.create())
+                .build();
+        ClamberService clamber = retrofit.create(ClamberService.class);
+        Log.d(TAG, "The id is: " + climbId + " and isChecked is: " + isChecked);
+        if (!isChecked) {
+
+            final Call<Project> createProjectCall = clamber.createProject(request);
+            createProjectCall.enqueue(new Callback<Project>() {
+                @Override
+                public void onResponse(Call<Project> call, Response<Project> response) {
+                    Log.d(TAG, "Successfully set up project for user: " + mainUser.getUserName());
+                }
+
+                @Override
+                public void onFailure(Call<Project> call, Throwable t) {
+                    Log.d(TAG, "Failed to set up project for user:" + mainUser.getUserName());
+                }
+            });
+        } else {
+            final Call<Boolean> removeProjectCall = clamber.removeProject(mainUser.getUserName(), climbId);
+            removeProjectCall.enqueue(new Callback<Boolean>() {
+                @Override
+                public void onResponse(Call<Boolean> call, Response<Boolean> response) {
+                    if (response.body()) {
+                        Log.d(TAG, "Successfully removed project for user: " + mainUser.getUserName());
+                    } else {
+                        Log.d(TAG, "Failed to delete project for user: " + mainUser.getUserName());
+
+                    }
+                }
+
+                @Override
+                public void onFailure(Call<Boolean> call, Throwable t) {
+                    Log.d(TAG, "Failed to delete project for user: " + mainUser.getUserName());
+                }
+            });
+        }
+
+    }
+    /**
+     * Method called from the ClimbRecyclerViewAdapter when the Completed Checkbox is clicked. It returns the
+     * climb Id and boolean value for whether or not the box is checked. With that information, a network
+     * call is made to either POST a new completed climb to the database or DELETE an existing one for the user.
+     * @param climbId - the id of the climb where the completed checkbox was selected
+     * @param isChecked - the boolean value of the completed checkbox.
+     */
+    @Override
+    public void onCompletedCheckBoxClicked(int climbId, boolean isChecked) {
+        UserClimbDataRequest request = new UserClimbDataRequest();
+        request.setClimbId(climbId);
+        request.setUsername(mainUser.getUserName());
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(HomePage.CONNECTION_WEB_ADDRESS)
+                .addConverterFactory(JacksonConverterFactory.create())
+                .build();
+        ClamberService clamber = retrofit.create(ClamberService.class);
+        Log.d(TAG, "The id is: " + climbId + " and isChecked is: " + isChecked);
+        if (!isChecked) {
+
+            final Call<Boolean> createCompletedCall = clamber.createCompleted(request);
+            createCompletedCall.enqueue(new Callback<Boolean>() {
+                @Override
+                public void onResponse(Call<Boolean> call, Response<Boolean> response) {
+                    Log.d(TAG, "Successfully set up completed climb for user: " + mainUser.getUserName());
+                }
+
+                @Override
+                public void onFailure(Call<Boolean> call, Throwable t) {
+                    Log.d(TAG, "Failed to set up completed climb for user:" + mainUser.getUserName());
+
+                }
+
+            });
+        } else {
+            final Call<Boolean> removeCompletedCall = clamber.removeCompleted(mainUser.getUserName(), climbId);
+            removeCompletedCall.enqueue(new Callback<Boolean>() {
+                @Override
+                public void onResponse(Call<Boolean> call, Response<Boolean> response) {
+                    if (response.body()) {
+                        Log.d(TAG, "Successfully removed completed climb for user: " + mainUser.getUserName());
+                    } else {
+                        Log.d(TAG, "Failed to delete completed climb for user: " + mainUser.getUserName());
+
+                    }
+                }
+
+                @Override
+                public void onFailure(Call<Boolean> call, Throwable t) {
+                    Log.d(TAG, "Failed to delete completed climb for user: " + mainUser.getUserName());
+
+                }
+            });
+        }
+    }
 }

--- a/app/src/main/java/com/rage/clamber/Fragments/ProjectsFragment.java
+++ b/app/src/main/java/com/rage/clamber/Fragments/ProjectsFragment.java
@@ -127,7 +127,7 @@ public class ProjectsFragment extends Fragment implements ClimbsRecyclerViewAdap
 
                 @Override
                 public void onFailure(Call<List<Climb>> call, Throwable t) {
-                    Log.d(TAG, "Failure when attempting to return projects for user");
+                    Log.d(TAG, "Failure when attempting to return projects for user", t);
                 }
             });
 
@@ -164,7 +164,7 @@ public class ProjectsFragment extends Fragment implements ClimbsRecyclerViewAdap
 
                 @Override
                 public void onFailure(Call<Project> call, Throwable t) {
-                    Log.d(TAG, "Failed to set up project for user:" + mainUser.getUserName());
+                    Log.d(TAG, "Failed to set up project for user:" + mainUser.getUserName(), t);
                 }
             });
         } else {
@@ -182,7 +182,7 @@ public class ProjectsFragment extends Fragment implements ClimbsRecyclerViewAdap
 
                 @Override
                 public void onFailure(Call<Boolean> call, Throwable t) {
-                    Log.d(TAG, "Failed to delete project for user: " + mainUser.getUserName());
+                    Log.d(TAG, "Failed to delete project for user: " + mainUser.getUserName(), t);
                 }
             });
         }
@@ -218,7 +218,7 @@ public class ProjectsFragment extends Fragment implements ClimbsRecyclerViewAdap
 
                 @Override
                 public void onFailure(Call<Boolean> call, Throwable t) {
-                    Log.d(TAG, "Failed to set up completed climb for user:" + mainUser.getUserName());
+                    Log.d(TAG, "Failed to set up completed climb for user:" + mainUser.getUserName(), t);
 
                 }
 
@@ -239,7 +239,7 @@ public class ProjectsFragment extends Fragment implements ClimbsRecyclerViewAdap
 
                 @Override
                 public void onFailure(Call<Boolean> call, Throwable t) {
-                    Log.d(TAG, "Failed to delete completed climb for user: " + mainUser.getUserName());
+                    Log.d(TAG, "Failed to delete completed climb for user: " + mainUser.getUserName(), t);
 
                 }
             });

--- a/app/src/main/java/com/rage/clamber/Fragments/WallSectionFragment.java
+++ b/app/src/main/java/com/rage/clamber/Fragments/WallSectionFragment.java
@@ -43,7 +43,7 @@ public class WallSectionFragment extends Fragment implements WallsPageRecyclerVi
     public static final String ARG_WALL_SECTION = "Wall Section Id";
     protected User mainUser;
     //TODO: Make List instead of ArrayList
-    protected ArrayList<WallSection> wallSections;
+    protected List<WallSection> wallSections;
     protected int wall;
 
 


### PR DESCRIPTION
- Updated the local ip address in home page
- Updated ClimbsRecyclerViewAdapter to have contain an onclick listener for the project checkbox and the completed climbs
  checkbox. Also added listener interfaces to return the climb id and boolean value to be used in the climbs Fragment and
  Projects Fragment to update the database.
- Updated ArrayList to List in the WallsRecyclerViewAdapter and WallSectionfragment.
- Added a POST and DELETE for projects and a POST and DELETE for completed climbs to the ClamberService interface
- Added the UserClimbDataRequest class to hold the username and climb id value. Used to pass that information to the
  database.
- modified the climbs and projects fragment to include POST and DELETE for projects and completed climbs.
